### PR TITLE
Handle CMD_RESPONSE type packet in streamed response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+/.cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ version = "0.3"
 
 [dependencies.serde]
 version = "1.0"
+features = ["derive"]
 
 [dependencies.serde_vici]
 version = "0.1"

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -32,7 +32,9 @@ type CommandSender = Sender<(Packet, Handler)>;
 type EventSender = Sender<(Packet, String, Registration, Handler)>;
 type ErrorHandlerSender = UnboundedSender<UnboundedSender<Error>>;
 
+
 #[derive(Deserialize)]
+/// A structure to handle all kind of CMD_RESPONSE
 struct Response {
     success: Option<bool>,
     errmsg: Option<String>

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,5 +1,3 @@
-use core::option::Option::None;
-
 use async_stream::try_stream;
 use futures_util::Stream;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -2,7 +2,7 @@ use core::option::Option::None;
 
 use async_stream::try_stream;
 use futures_util::Stream;
-use serde::{de::DeserializeOwned, Serialize, Deserialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tokio::{
     io::{AsyncRead, AsyncWrite},
     sync::mpsc::{self, Sender, UnboundedSender},
@@ -32,12 +32,11 @@ type CommandSender = Sender<(Packet, Handler)>;
 type EventSender = Sender<(Packet, String, Registration, Handler)>;
 type ErrorHandlerSender = UnboundedSender<UnboundedSender<Error>>;
 
-
 #[derive(Deserialize)]
 /// A structure to handle all kind of CMD_RESPONSE
 struct Response {
-    success: Option<bool>,
-    errmsg: Option<String>
+    pub success: Option<bool>,
+    pub errmsg: Option<String>,
 }
 
 /// A structure to interact with the IKE daemon using the VICI protocol.
@@ -258,16 +257,7 @@ impl Client {
 
             match cmd_response.success {
                 Some(true) => {},
-                Some(false) => {
-                    match cmd_response.errmsg {
-                        Some(errmsg) => {
-                            Err(Error::data(ErrorCode::CommandFailed(errmsg)))?;
-                        },
-                        None => {
-                            Err(Error::data(ErrorCode::CommandFailed("unknown".to_string())))?;
-                        }
-                    }
-                },
+                Some(false) => Err(Error::data(ErrorCode::CommandFailed(cmd_response.errmsg)))?,
                 None => {},
             }
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 //! Failures to interact with the IKE daemon.
 
-use core::{option::Option::None, result};
+use core::result;
 use std::{
     error,
     fmt::{self, Debug, Display},
@@ -120,7 +120,7 @@ impl From<Error> for io::Error {
             Category::Data => io::Error::new(io::ErrorKind::InvalidData, e),
             Category::Closed => io::Error::new(io::ErrorKind::BrokenPipe, e),
             Category::UnknownCmd | Category::UnknownEvent => io::Error::new(io::ErrorKind::Unsupported, e),
-            Category::CmdFailure => io::Error::new(io::ErrorKind::Other, e),
+            Category::CmdFailure => io::Error::other(e),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 //! Failures to interact with the IKE daemon.
 
-use core::result;
+use core::{option::Option::None, result};
 use std::{
     error,
     fmt::{self, Debug, Display},
@@ -160,7 +160,7 @@ pub(crate) enum ErrorCode {
     UnknownEvent(String),
 
     /// Issued command failed.
-    CommandFailed(String)
+    CommandFailed(Option<String>),
 }
 
 impl Display for ErrorCode {
@@ -175,7 +175,10 @@ impl Display for ErrorCode {
             ErrorCode::UnexpectedPacket(ref packet_type) => f.write_fmt(format_args!("unexpected packet type {packet_type}")),
             ErrorCode::UnknownCmd => f.write_str("unknown command"),
             ErrorCode::UnknownEvent(ref event) => f.write_fmt(format_args!("unknown event {event}")),
-            ErrorCode::CommandFailed(ref reason) => f.write_fmt(format_args!("command failed - {reason}")),
+            ErrorCode::CommandFailed(ref reason) => match reason {
+                Some(errmsg) => f.write_fmt(format_args!("command failed: {errmsg}")),
+                None => f.write_fmt(format_args!("command failed")),
+            },
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,7 @@ impl Error {
             | ErrorCode::HandlerClosedWhileStreaming(_) => Category::Closed,
             ErrorCode::UnknownCmd => Category::UnknownCmd,
             ErrorCode::UnknownEvent(_) => Category::UnknownEvent,
+            ErrorCode::CommandFailed(_) => Category::CmdFailure,
         }
     }
 
@@ -95,6 +96,8 @@ pub enum Category {
 
     /// The error was caused by an unknown event request.
     UnknownEvent,
+
+    CmdFailure,
 }
 
 impl From<io::Error> for Error {
@@ -117,6 +120,7 @@ impl From<Error> for io::Error {
             Category::Data => io::Error::new(io::ErrorKind::InvalidData, e),
             Category::Closed => io::Error::new(io::ErrorKind::BrokenPipe, e),
             Category::UnknownCmd | Category::UnknownEvent => io::Error::new(io::ErrorKind::Unsupported, e),
+            Category::CmdFailure => io::Error::new(io::ErrorKind::Other, e),
         }
     }
 }
@@ -154,6 +158,9 @@ pub(crate) enum ErrorCode {
 
     /// Unknown event has been requested.
     UnknownEvent(String),
+
+    /// Issued command failed.
+    CommandFailed(String)
 }
 
 impl Display for ErrorCode {
@@ -168,6 +175,7 @@ impl Display for ErrorCode {
             ErrorCode::UnexpectedPacket(ref packet_type) => f.write_fmt(format_args!("unexpected packet type {packet_type}")),
             ErrorCode::UnknownCmd => f.write_str("unknown command"),
             ErrorCode::UnknownEvent(ref event) => f.write_fmt(format_args!("unknown event {event}")),
+            ErrorCode::CommandFailed(ref reason) => f.write_fmt(format_args!("command failed - {reason}")),
         }
     }
 }

--- a/tests/stream_request_with_return.rs
+++ b/tests/stream_request_with_return.rs
@@ -1,0 +1,347 @@
+use rsvici::{Client, Error};
+
+use futures_util::{pin_mut, stream::TryStreamExt};
+use pretty_assertions::assert_eq;
+use serde::{Deserialize, Serialize};
+use tokio_test::io::Builder;
+
+#[derive(Debug, Deserialize, Eq, PartialEq)]
+struct ControlLog {
+    group: String,
+    level: u32,
+    #[serde(rename = "ikesa-name")]
+    ikesa_name: String,
+    #[serde(rename = "ikesa-uniqueid")]
+    ikesa_uniqueid: u64,
+    msg: String
+}
+
+#[derive(Debug, Serialize)]
+struct Initiate {
+    ike: String,
+    child: String,
+}
+
+#[tokio::test]
+async fn stream_request_with_success() {
+    #[rustfmt::skip]
+    let mock_stream = Builder::new()
+        .write(&[
+            // header
+            0, 0, 0, 13,
+            // packet type
+            3, 11, b'c', b'o', b'n', b't', b'r', b'o', b'l', b'-', b'l', b'o', b'g',
+        ])
+        .read(&[
+            // header
+            0, 0, 0, 1,
+            // packet type
+            5,
+        ])
+        .write(&[
+            // header
+            0, 0, 0, 38,
+            // packet type
+            0, 8, b'i', b'n', b'i', b't', b'i', b'a', b't', b'e',
+            // ike = gw-gw
+            3, 3, b'i', b'k', b'e', 0, 5, b'g', b'w', b'-', b'g', b'w',
+            // child = net-net
+            3, 5, b'c', b'h', b'i', b'l', b'd', 0, 7, b'n', b'e', b't', b'-', b'n', b'e', b't',
+        ])
+        .read(&[
+            // header
+            0, 0, 0, 107,
+            // packet type
+            7, 11, b'c', b'o', b'n', b't', b'r', b'o', b'l', b'-', b'l', b'o', b'g',
+            // group = IKE
+            3, 5, b'g', b'r', b'o', b'u', b'p', 0, 3, b'I', b'K', b'E',
+            // level = 1
+            3, 5, b'l', b'e', b'v', b'e', b'l', 0, 1, b'1',
+            // ikesa-name = gw-gw
+            3, 10, b'i', b'k', b'e', b's', b'a', b'-', b'n', b'a', b'm', b'e', 0, 5, b'g', b'w', b'-', b'g', b'w',
+            // ikesa-uniqueid = 12
+            3, 14, b'i', b'k', b'e', b's', b'a', b'-', b'u', b'n', b'i', b'q', b'u', b'e', b'i', b'd', 0, 2, b'1', b'2',
+            // msg = IKE_SA gw-gw[12] initiated
+            3, 3, b'm', b's', b'g', 0, 26, b'I', b'K', b'E', b'_', b'S', b'A', b' ', b'g', b'w', b'-', b'g', b'w', b'[', b'1', b'2', b']', b' ', b'i', b'n', b'i', b't', b'i', b'a', b't', b'e', b'd',
+        ])
+        .read(&[
+            // header
+            0, 0, 0, 103,
+            // packet type
+            7, 11, b'c', b'o', b'n', b't', b'r', b'o', b'l', b'-', b'l', b'o', b'g',
+            // group = ENC
+            3, 5, b'g', b'r', b'o', b'u', b'p', 0, 3, b'E', b'N', b'C',
+            // level = 1
+            3, 5, b'l', b'e', b'v', b'e', b'l', 0, 1, b'1',
+            // ikesa-name = gw-gw
+            3, 10, b'i', b'k', b'e', b's', b'a', b'-', b'n', b'a', b'm', b'e', 0, 5, b'g', b'w', b'-', b'g', b'w',
+            // ikesa-uniqueid = 12
+            3, 14, b'i', b'k', b'e', b's', b'a', b'-', b'u', b'n', b'i', b'q', b'u', b'e', b'i', b'd', 0, 2, b'1', b'2',
+            // msg = AES-CBC-128 negotiated
+            3, 3, b'm', b's', b'g', 0, 22, b'A', b'E', b'S', b'-', b'C', b'B', b'C', b'-', b'1', b'2', b'8', b' ', b'n', b'e', b'g', b'o', b't', b'i', b'a', b't', b'e', b'd',
+        ])
+        .read(&[
+            // header
+            0, 0, 0, 15,
+            // packet type
+            1,
+            // success = yes
+            3, 7, b's', b'u', b'c', b'c', b'e', b's', b's', 0, 3, b'y', b'e', b's',
+        ])
+        .write(&[
+            // header
+            0, 0, 0, 13,
+            // packet type
+            4, 11, b'c', b'o', b'n', b't', b'r', b'o', b'l', b'-', b'l', b'o', b'g',
+        ])
+        .read(&[
+            // header
+            0, 0, 0, 1,
+            // packet type
+            5,
+        ])
+        .build();
+
+    let mut client = Client::new(mock_stream);
+    let initiate = Initiate {
+        ike: "gw-gw".to_string(),
+        child: "net-net".to_string(),
+    };
+    
+    let stream = client.stream_request::<Initiate, ControlLog>("initiate", "control-log", initiate);
+    let actual: Vec<ControlLog> = stream.try_collect().await.unwrap();
+
+    assert_eq!(
+        actual,
+        vec![
+            ControlLog {
+                group: "IKE".to_string(),
+                level: 1,
+                ikesa_name: "gw-gw".to_string(),
+                ikesa_uniqueid: 12,
+                msg: "IKE_SA gw-gw[12] initiated".to_string(),
+            },
+            ControlLog {
+                group: "ENC".to_string(),
+                level: 1,
+                ikesa_name: "gw-gw".to_string(),
+                ikesa_uniqueid: 12,
+                msg: "AES-CBC-128 negotiated".to_string(),
+            },
+        ]
+    );
+}
+
+#[tokio::test]
+async fn stream_request_with_failure() {
+    #[rustfmt::skip]
+    let mock_stream = Builder::new()
+        .write(&[
+            // header
+            0, 0, 0, 13,
+            // packet type
+            3, 11, b'c', b'o', b'n', b't', b'r', b'o', b'l', b'-', b'l', b'o', b'g',
+        ])
+        .read(&[
+            // header
+            0, 0, 0, 1,
+            // packet type
+            5,
+        ])
+        .write(&[
+            // header
+            0, 0, 0, 38,
+            // packet type
+            0, 8, b'i', b'n', b'i', b't', b'i', b'a', b't', b'e',
+            // ike = gw-gw
+            3, 3, b'i', b'k', b'e', 0, 5, b'g', b'w', b'-', b'g', b'w',
+            // child = net-net
+            3, 5, b'c', b'h', b'i', b'l', b'd', 0, 7, b'n', b'e', b't', b'-', b'n', b'e', b't',
+        ])
+        .read(&[
+            // header
+            0, 0, 0, 100,
+            // packet type
+            7, 11, b'c', b'o', b'n', b't', b'r', b'o', b'l', b'-', b'l', b'o', b'g',
+            // group = ENC
+            3, 5, b'g', b'r', b'o', b'u', b'p', 0, 3, b'E', b'N', b'C',
+            // level = 1
+            3, 5, b'l', b'e', b'v', b'e', b'l', 0, 1, b'1',
+            // ikesa-name = gw-gw
+            3, 10, b'i', b'k', b'e', b's', b'a', b'-', b'n', b'a', b'm', b'e', 0, 5, b'g', b'w', b'-', b'g', b'w',
+            // ikesa-uniqueid = 12
+            3, 14, b'i', b'k', b'e', b's', b'a', b'-', b'u', b'n', b'i', b'q', b'u', b'e', b'i', b'd', 0, 2, b'1', b'2',
+            // msg = failed to negotiate
+            3, 3, b'm', b's', b'g', 0, 19, b'f', b'a', b'i', b'l', b'e', b'd', b' ', b't', b'o', b' ', b'n', b'e', b'g', b'o', b't', b'i', b'a', b't', b'e',
+        ])
+        .read(&[
+            // header
+            0, 0, 0, 55,
+            // packet type
+            1,
+            // success = no
+            3, 7, b's', b'u', b'c', b'c', b'e', b's', b's', 0, 2, b'n', b'o',
+            // errmsg = child initiation net-net failed
+            3, 6, b'e', b'r', b'r', b'm', b's', b'g', 0, 31, b'c', b'h', b'i', b'l', b'd', b' ', b'i', b'n', b'i', b't', b'i', b'a', b't', b'i', b'o', b'n', b' ', b'n', b'e', b't', b'-', b'n', b'e', b't', b' ', b'f', b'a', b'i', b'l', b'e', b'd',
+        ])
+        .write(&[
+            // header
+            0, 0, 0, 13,
+            // packet type
+            4, 11, b'c', b'o', b'n', b't', b'r', b'o', b'l', b'-', b'l', b'o', b'g',
+        ])
+        .read(&[
+            // header
+            0, 0, 0, 1,
+            // packet type
+            5,
+        ])
+        .build();
+
+    let mut client = Client::new(mock_stream);
+    let initiate = Initiate {
+        ike: "gw-gw".to_string(),
+        child: "net-net".to_string(),
+    };
+    
+    let stream = client.stream_request::<Initiate, ControlLog>("initiate", "control-log", initiate);
+
+    pin_mut!(stream);
+
+    let mut items: Vec<ControlLog> = Vec::new();
+    let mut err: Option<Error> = None;
+
+    loop {
+        match stream.try_next().await {
+            Ok(Some(item)) => items.push(item),
+            Ok(None) => break,
+            Err(e) => {
+                err = Some(e);
+                break;
+            }
+        }
+    }
+
+    assert_eq!(
+        items,
+        vec![
+            ControlLog {
+                group: "ENC".to_string(),
+                level: 1,
+                ikesa_name: "gw-gw".to_string(),
+                ikesa_uniqueid: 12,
+                msg: "failed to negotiate".to_string(),
+            },
+        ]
+    );
+    assert_eq!(
+        err.map(|e| e.to_string()),
+        Some("command failed - child initiation net-net failed".to_string())
+    );
+}
+
+#[tokio::test]
+async fn stream_request_with_failure_no_errmsg() {
+    #[rustfmt::skip]
+    let mock_stream = Builder::new()
+        .write(&[
+            // header
+            0, 0, 0, 13,
+            // packet type
+            3, 11, b'c', b'o', b'n', b't', b'r', b'o', b'l', b'-', b'l', b'o', b'g',
+        ])
+        .read(&[
+            // header
+            0, 0, 0, 1,
+            // packet type
+            5,
+        ])
+        .write(&[
+            // header
+            0, 0, 0, 38,
+            // packet type
+            0, 8, b'i', b'n', b'i', b't', b'i', b'a', b't', b'e',
+            // ike = gw-gw
+            3, 3, b'i', b'k', b'e', 0, 5, b'g', b'w', b'-', b'g', b'w',
+            // child = net-net
+            3, 5, b'c', b'h', b'i', b'l', b'd', 0, 7, b'n', b'e', b't', b'-', b'n', b'e', b't',
+        ])
+        .read(&[
+            // header
+            0, 0, 0, 100,
+            // packet type
+            7, 11, b'c', b'o', b'n', b't', b'r', b'o', b'l', b'-', b'l', b'o', b'g',
+            // group = ENC
+            3, 5, b'g', b'r', b'o', b'u', b'p', 0, 3, b'E', b'N', b'C',
+            // level = 1
+            3, 5, b'l', b'e', b'v', b'e', b'l', 0, 1, b'1',
+            // ikesa-name = gw-gw
+            3, 10, b'i', b'k', b'e', b's', b'a', b'-', b'n', b'a', b'm', b'e', 0, 5, b'g', b'w', b'-', b'g', b'w',
+            // ikesa-uniqueid = 12
+            3, 14, b'i', b'k', b'e', b's', b'a', b'-', b'u', b'n', b'i', b'q', b'u', b'e', b'i', b'd', 0, 2, b'1', b'2',
+            // msg = failed to negotiate
+            3, 3, b'm', b's', b'g', 0, 19, b'f', b'a', b'i', b'l', b'e', b'd', b' ', b't', b'o', b' ', b'n', b'e', b'g', b'o', b't', b'i', b'a', b't', b'e',
+        ])
+        .read(&[
+            // header
+            0, 0, 0, 14,
+            // packet type
+            1,
+            // success = no
+            3, 7, b's', b'u', b'c', b'c', b'e', b's', b's', 0, 2, b'n', b'o',
+        ])
+        .write(&[
+            // header
+            0, 0, 0, 13,
+            // packet type
+            4, 11, b'c', b'o', b'n', b't', b'r', b'o', b'l', b'-', b'l', b'o', b'g',
+        ])
+        .read(&[
+            // header
+            0, 0, 0, 1,
+            // packet type
+            5,
+        ])
+        .build();
+
+    let mut client = Client::new(mock_stream);
+    let initiate = Initiate {
+        ike: "gw-gw".to_string(),
+        child: "net-net".to_string(),
+    };
+    
+    let stream = client.stream_request::<Initiate, ControlLog>("initiate", "control-log", initiate);
+
+    pin_mut!(stream);
+
+    let mut items: Vec<ControlLog> = Vec::new();
+    let mut err: Option<Error> = None;
+
+    loop {
+        match stream.try_next().await {
+            Ok(Some(item)) => items.push(item),
+            Ok(None) => break,
+            Err(e) => {
+                err = Some(e);
+                break;
+            }
+        }
+    }
+
+    assert_eq!(
+        items,
+        vec![
+            ControlLog {
+                group: "ENC".to_string(),
+                level: 1,
+                ikesa_name: "gw-gw".to_string(),
+                ikesa_uniqueid: 12,
+                msg: "failed to negotiate".to_string(),
+            },
+        ]
+    );
+    assert_eq!(
+        err.map(|e| e.to_string()),
+        Some("command failed - unknown".to_string())
+    );
+}

--- a/tests/stream_request_with_return.rs
+++ b/tests/stream_request_with_return.rs
@@ -1,3 +1,5 @@
+use core::option::Option::None;
+
 use rsvici::{Client, Error};
 
 use futures_util::{pin_mut, stream::TryStreamExt};
@@ -13,7 +15,7 @@ struct ControlLog {
     ikesa_name: String,
     #[serde(rename = "ikesa-uniqueid")]
     ikesa_uniqueid: u64,
-    msg: String
+    msg: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -107,7 +109,7 @@ async fn stream_request_with_success() {
         ike: "gw-gw".to_string(),
         child: "net-net".to_string(),
     };
-    
+
     let stream = client.stream_request::<Initiate, ControlLog>("initiate", "control-log", initiate);
     let actual: Vec<ControlLog> = stream.try_collect().await.unwrap();
 
@@ -203,7 +205,7 @@ async fn stream_request_with_failure() {
         ike: "gw-gw".to_string(),
         child: "net-net".to_string(),
     };
-    
+
     let stream = client.stream_request::<Initiate, ControlLog>("initiate", "control-log", initiate);
 
     pin_mut!(stream);
@@ -218,26 +220,21 @@ async fn stream_request_with_failure() {
             Err(e) => {
                 err = Some(e);
                 break;
-            }
+            },
         }
     }
 
     assert_eq!(
         items,
-        vec![
-            ControlLog {
-                group: "ENC".to_string(),
-                level: 1,
-                ikesa_name: "gw-gw".to_string(),
-                ikesa_uniqueid: 12,
-                msg: "failed to negotiate".to_string(),
-            },
-        ]
+        vec![ControlLog {
+            group: "ENC".to_string(),
+            level: 1,
+            ikesa_name: "gw-gw".to_string(),
+            ikesa_uniqueid: 12,
+            msg: "failed to negotiate".to_string(),
+        },]
     );
-    assert_eq!(
-        err.map(|e| e.to_string()),
-        Some("command failed - child initiation net-net failed".to_string())
-    );
+    assert_eq!(err.map(|e| e.to_string()), Some("command failed: child initiation net-net failed".to_string()));
 }
 
 #[tokio::test]
@@ -309,7 +306,7 @@ async fn stream_request_with_failure_no_errmsg() {
         ike: "gw-gw".to_string(),
         child: "net-net".to_string(),
     };
-    
+
     let stream = client.stream_request::<Initiate, ControlLog>("initiate", "control-log", initiate);
 
     pin_mut!(stream);
@@ -324,24 +321,19 @@ async fn stream_request_with_failure_no_errmsg() {
             Err(e) => {
                 err = Some(e);
                 break;
-            }
+            },
         }
     }
 
     assert_eq!(
         items,
-        vec![
-            ControlLog {
-                group: "ENC".to_string(),
-                level: 1,
-                ikesa_name: "gw-gw".to_string(),
-                ikesa_uniqueid: 12,
-                msg: "failed to negotiate".to_string(),
-            },
-        ]
+        vec![ControlLog {
+            group: "ENC".to_string(),
+            level: 1,
+            ikesa_name: "gw-gw".to_string(),
+            ikesa_uniqueid: 12,
+            msg: "failed to negotiate".to_string(),
+        },]
     );
-    assert_eq!(
-        err.map(|e| e.to_string()),
-        Some("command failed - unknown".to_string())
-    );
+    assert_eq!(err.map(|e| e.to_string()), Some("command failed".to_string()));
 }

--- a/tests/stream_request_with_return.rs
+++ b/tests/stream_request_with_return.rs
@@ -1,5 +1,3 @@
-use core::option::Option::None;
-
 use rsvici::{Client, Error};
 
 use futures_util::{pin_mut, stream::TryStreamExt};


### PR DESCRIPTION
Some of the VICI stream responses end with `CMD_RESPONSE` type packet. The behavior is very ambiguous.

For example:

- Response from `list-conns` or `list-sas` normally stream their event responses and end.
- From `initiate` or `terminate`, control log events are streamed and at the end a `CMD_RESPONSE` packet is sent. This has two fields:
    1. `success` - a boolean field indicating command execution end status, i.e., success or failure
    2. An optional `errmsg` in case of failure

- From `list-certs` (and maybe from some others) we indeed get a `CMD_RESPONSE` but with no fields

To handle all such scenarios, packet type checking and message deserializations are decoupled in `stream_request`.

1. First, the packet type is determined
2. If it is of type `EVENT`, deserialize and handle accordingly
3. If it is of type `CMD_RESPONSE`, deserialize into an interenal `Response` struct:
```rust
struct Response {
    success: Option<bool>,
    errmsg: Option<String>
}
```

This will handle all possible cases:

- For blank `CMD_RESPONSE`, we will assume success if everything goes well
- For `CMD_RESPONSE` with fields, we check `success`. If it is true then all Ok, else we raise `CommandFailed` error with the `errmsg`, if any.

This behavior is similar to the official client libraries - [python code](https://github.com/strongswan/strongswan/blob/master/src/libcharon/plugins/vici/python/vici/session.py#L112) [ruby code](https://github.com/strongswan/strongswan/blob/master/src/libcharon/plugins/vici/ruby/lib/vici.rb#L633)

This is related to #10 