### PR TITLE
Fix compatibility with platforms other than unix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@
 //! [Server-issued events]:      https://github.com/strongswan/strongswan/blob/5.9.5/src/libcharon/plugins/vici/README.md#server-issued-events
 
 #[doc(inline)]
-pub use crate::client::{tcp, unix, Client};
+pub use crate::client::*;
 #[doc(inline)]
 pub use crate::error::Error;
 


### PR DESCRIPTION
This PR fixes compatibility issues with non-`unix` platforms, like on Windows:

```
error[E0432]: unresolved import `crate::client::unix`
  --> src\lib.rs:55:30
   |
55 | pub use crate::client::{tcp, unix, Client};
   |                              ^^^^ no `unix` in `client`
   |
note: found an item that was configured out
  --> src\client\mod.rs:21:9
   |
20 | #[cfg(unix)]
   |       ---- the item is gated here
21 | pub mod unix;
   |         ^^^^

For more information about this error, try `rustc --explain E0432`.
error: could not compile `rsvici` (lib) due to 1 previous error
```